### PR TITLE
fix: add argument "numeric_only" to df.count function

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -4,7 +4,7 @@ import matplotlib as mpl
 
 class DataCleaningTestCase(unittest.TestCase):
     def test_data_cleaning(self):
-        actual = int(time_series_visualizer.df.count())
+        actual = int(time_series_visualizer.df.count(numric_only=True))
         expected = 1238
         self.assertEqual(actual, expected, "Expected DataFrame count after cleaning to be 1238.")
 


### PR DESCRIPTION
I added numeric_only=true argument to df.count just like recommended. 

issue: https://github.com/freeCodeCamp/freeCodeCamp/issues/39244#issue-656076354