### PR TITLE
fix(curriculum): change numbers in test error message

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -83,10 +83,10 @@ class BoxPlotTestCase(unittest.TestCase):
         self.assertEqual(actual, expected, "Expected box plot 1 ylabel to be 'Page Views'")
         actual = self.ax2.get_xlabel()
         expected = "Month"
-        self.assertEqual(actual, expected, "Expected box plot 1 xlabel to be 'Month'")
+        self.assertEqual(actual, expected, "Expected box plot 2 xlabel to be 'Month'")
         actual = self.ax2.get_ylabel()
         expected = "Page Views"
-        self.assertEqual(actual, expected, "Expected box plot 1 ylabel to be 'Page Views'")
+        self.assertEqual(actual, expected, "Expected box plot 2 ylabel to be 'Page Views'")
         actual = []
         for label in self.ax1.get_xaxis().get_majorticklabels():
             actual.append(label.get_text())
@@ -109,7 +109,7 @@ class BoxPlotTestCase(unittest.TestCase):
         self.assertEqual(actual, expected, "Expected box plot 1 title to be 'Year-wise Box Plot (Trend)'")
         actual = self.ax2.get_title()
         expected = "Month-wise Box Plot (Seasonality)"
-        self.assertEqual(actual, expected, "Expected box plot 1 title to be 'Month-wise Box Plot (Seasonality)'")
+        self.assertEqual(actual, expected, "Expected box plot 2 title to be 'Month-wise Box Plot (Seasonality)'")
 
     def test_box_plot_number_of_boxes(self):
         actual = len(self.ax1.lines) / 6 # Every box has 6 lines


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes [#47294](https://github.com/freeCodeCamp/freeCodeCamp/issues/47294)

<!-- Feel free to add any additional description of changes below this line -->

Change the number in msg argument of tests so they correctly convey which plot's title and labels have error.

Affected page:
Data Analysis with Python > Data Analysis with Python Projects > Page View Time Series Visualizer
https://www.freecodecamp.org/learn/data-analysis-with-python/data-analysis-with-python-projects/page-view-time-series-visualizer

The error messages have been tested and previewed in Repl.it console.

![change_numbers_in_msg_argument_of_tests](https://user-images.githubusercontent.com/44451585/185174268-ab732741-8a1e-482f-938c-a351ab2afc8d.png)

