### PR TITLE
fix retrieving of actual value in test_module.py

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -4,7 +4,7 @@ import matplotlib as mpl
 
 class DataCleaningTestCase(unittest.TestCase):
     def test_data_cleaning(self):
-        actual = int(time_series_visualizer.df.count(numeric_only=True))
+        actual = int(time_series_visualizer.df.count(numeric_only=True)[0])
         expected = 1238
         self.assertEqual(actual, expected, "Expected DataFrame count after cleaning to be 1238.")
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a fix in the retrieving of the actual value in a test.

Currently, test fails because of an attempt to convert a series to an int. The changes in this PR fix it.